### PR TITLE
Fix bug with wrong key array size

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -41,7 +41,7 @@ int main(int argc, char* argv[]) {
         if (gen == "-g") {
             // generate key
             unsigned char alphabet[] = "abcdefghijklmnopqrstuvwxyz1234567890";
-            char key[8];
+            char key[9];
             for(int i = 0; i < 8; ++i) {
                 key[i] = alphabet[rand() % 36];
                 inputKey.push_back(key[i]);


### PR DESCRIPTION
Hi!
When executing a program with "-g" option, I've run into an exception saying "...trying to get value out of range..." on line 49.
And it's obviously, the array for only 8 symbols is created on line 44. And then, on line 49, we're trying to get the 9th element of array. 
So, I fixed it by simply changing initial array size. Hope it's useful for you.
And thank you for your great and elegant work!
